### PR TITLE
Add a domain auth mode (traefik compatibility)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Required. The password that will be asked to the user
 
 Optional. A path to the background image of the login page
 
+### AUTH_MODE
+
+Optional. `http` or `domain` (see below).
+Default is `http`.
+
+### AUTH_DOMAIN_URL
+
+Optional. When using domain (SSO) mode, set this to the URL pointing to the authentication container. 
+
 ## Usage
 
 Nestor is an ASGI application and should be started via an ASGI server such as `uvicorn`.
@@ -39,6 +48,7 @@ Nestor is an ASGI application and should be started via an ASGI server such as `
 SECRET_KEY="verysecret" PASSWORD="pipo" uvicorn --root-path /nestor nestor:app
 ```
 
+### HTTP authentication (Nginx, apache)
 Nestor aims to be used via the `ngx_http_auth_request_module` of nginx. Here is an example nginx configuration for nginx
 
 ```
@@ -73,4 +83,46 @@ RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target
+```
+
+### Domain authentication (Traefik)
+Nestor can also be used as a simplified single sign-on (SSO) authenticator in a containerized environnement. A setup with Traefik's `forwardauth` middleware is presented below :
+
+```yaml
+# docker-compose.yml
+  nestor:
+    build: ./nestor
+    container_name: "nestor"
+    env_file: ./nestor/nestor.env
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.nestor.rule=Host(`auth.mydomain.com`)"
+      - "traefik.http.routers.nestor.tls=true"
+      - "traefik.http.routers.nestor.tls.certresolver=letsencrypt"
+      - "traefik.http.middlewares.domain-auth.forwardauth.address=http://nestor:8123/auth"
+
+  example-app:
+    (...)
+    labels:
+      - "traefik.http.routers.example-app.middlewares=domain-auth"
+```
+
+```sh
+# nestor/nestor.env
+(...)
+AUTH_MODE="domain"
+AUTH_DOMAIN_URL="https://auth.mydomain.com"
+```
+
+```dockerfile
+# nestor/Dockerfile
+# with nestor source in the `src` subdirectory
+FROM python:3.11-slim
+WORKDIR /code
+COPY ./src/requirements.txt /code/requirements.txt
+RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+COPY ./src/. /code/
+
+EXPOSE 8123
+CMD ["uvicorn", "nestor:app", "--proxy-headers", "--host", "0.0.0.0", "--port", "8123", "--forwarded-allow-ips", "*"]
 ```

--- a/views/login.html
+++ b/views/login.html
@@ -91,7 +91,8 @@ background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/s
     <div class="box">
       <h1>Password protected</h1>
       <form method="post" action="{{ url_for('login') }}">
-          <input type="hidden" name="next" value="{{ redir or request.headers.get('X-Original-URI') }}" />
+          <input type="hidden" name="next"
+	      value="{{ redir or request.headers.get('X-Original-URI') or request.query_params.get('redirect') }}" />
           <input type="password" placeholder="Password" name="password"/>
           <button type="submit">Go !</button>
       </form>


### PR DESCRIPTION
Hello!
This PR adds a "domain auth" mode, which make `nestor` act as a simplified SSO authenticator in a dockerized environment, behind a Traefik proxy.
I have updated the README with an example configuration for this setup.
Tell me what you think!